### PR TITLE
Pass common validator options to #record.errors.add

### DIFF
--- a/lib/active_model/validations/uuid_validator.rb
+++ b/lib/active_model/validations/uuid_validator.rb
@@ -19,7 +19,7 @@ module ActiveModel
       end
 
       def validate_each(record, attribute, value)
-        record.errors.add(attribute, :not_an_uuid) unless value =~ @re
+        record.errors.add(attribute, :not_an_uuid, options) unless value =~ @re
       end
 
     end

--- a/test/uuid_validator_test.rb
+++ b/test/uuid_validator_test.rb
@@ -133,5 +133,29 @@ describe ActiveModel::Validations::UuidValidator do
       end
     end
   end
+
+  describe "validates :key, :uuid => { message: 'UUID error' } " do
+    before do
+      TestModel.validates :key, :uuid => { message: "UUID error" }
+    end
+
+    describe "when nil" do
+      it "is invalid" do
+        must_be_error nil, "UUID error"
+      end
+    end
+
+    describe "when empty string" do
+      it "is invalid" do
+        must_be_error "", "UUID error"
+      end
+    end
+
+    describe "when non number" do
+      it "is invalid" do
+        must_be_error "550e8400-e29b-41d4-a716-XXXXXXXXXXXX", "UUID error"
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
Hi!

I've added third argument to #record.errors.add so user can provide his own error message to validator.

P.S. Thanks for the library :)
